### PR TITLE
correct image path in docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Rainloop is a simple, modern & fast web-based client. More details on the [offic
 # https://github.com/hardware/mailserver/blob/master/docker-compose.sample.yml
 
 rainloop:
-  image: hardware/rainloop
+  image: hiloyt/rainloop
   container_name: rainloop
   volumes:
     - /mnt/docker/rainloop:/rainloop/data


### PR DESCRIPTION
If you want I can create another pull request for a complete docker-compose example including Le'ts Encrypt support with Traefik I'm currently using for myself:
https://git.2li.ch/Nebucatnetzer/docker_systems/src/branch/master/rainloop